### PR TITLE
test and fix for find-missing

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -137,7 +137,8 @@ class Node {
       cids.add(node)
     }
     const result = node.entryList.find(key, this.compare)
-    if (result === null) throw new Error('Not found')
+    if (result === null ||
+      (result[1].key.toString() !== key.toString())) throw new Error('Not found')
     const [, entry] = result
     return entry
   }

--- a/test/test-map.js
+++ b/test/test-map.js
@@ -311,6 +311,13 @@ describe('map', () => {
       if (e.message !== 'Not found') throw e
     }
     same(threw, true)
+    try {
+      await root.getEntry('missing')
+      threw = false
+    } catch (e) {
+      if (e.message !== 'Not found') throw e
+    }
+    same(threw, true)
   })
   it('leaf', async () => {
     const { get, put } = storage()


### PR DESCRIPTION
this is the behavior I think we need for downstream consumers, b/c Map.get hides the internal key, so downstream code can filter on it.

the `toString()` was needed but maybe there is a more efficient way