### PR TITLE
Failing Fuzz test

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -55,7 +55,7 @@ class EntryList {
           if (comp > -1) {
             found.push(keys.pop())
           } else {
-            break
+            break // this is the only branch that hits if the new key sorts before the earliest key in the tree
           }
         } else {
           if (comp === 0) {

--- a/test/test-map.js
+++ b/test/test-map.js
@@ -35,7 +35,7 @@ const verify = (check, node) => {
 const createList = (entries) => entries.map(([key, value]) => ({ key, value }))
 
 const list = createList([
-  ['^', 1],
+  ['a', 1],
   ['b', 1],
   ['bb', 2],
   ['c', 1],
@@ -82,15 +82,15 @@ describe('map', () => {
       await put(await node.block)
       root = node
     }
-    const { result: entries, cids } = await root.getEntries(['^', 'zz'])
+    const { result: entries, cids } = await root.getEntries(['a', 'zz'])
     same((await cids.all()).size, 5)
     same(entries.length, 2)
     const [a, zz] = entries
-    same(a.key, '^')
+    same(a.key, 'a')
     same(a.value, 1)
     same(zz.key, 'zz')
     same(zz.value, 2)
-    const { result: values } = await root.getMany(['^', 'zz'])
+    const { result: values } = await root.getMany(['a', 'zz'])
     same(values, [1, 2])
   })
   it('getRangeEntries', async () => {
@@ -110,9 +110,9 @@ describe('map', () => {
     verify(entries, 1, 8)
     entries = await range('', 'zzz')
     verify(entries)
-    entries = await range('^', 'zz')
+    entries = await range('a', 'zz')
     verify(entries, 0, 9)
-    entries = await range('^', 'c')
+    entries = await range('a', 'c')
     verify(entries, 0, 3)
   })
   it('getAllEntries', async () => {
@@ -154,7 +154,7 @@ describe('map', () => {
     same(await _get('dd'), 2)
     same(await _get('d'), -1)
     const expected = [
-      ['^', 1],
+      ['a', 1],
       ['b', 1],
       ['bb', 2],
       ['c', 1],

--- a/test/test-map.js
+++ b/test/test-map.js
@@ -35,7 +35,7 @@ const verify = (check, node) => {
 const createList = (entries) => entries.map(([key, value]) => ({ key, value }))
 
 const list = createList([
-  ['a', 1],
+  ['^', 1],
   ['b', 1],
   ['bb', 2],
   ['c', 1],
@@ -82,15 +82,15 @@ describe('map', () => {
       await put(await node.block)
       root = node
     }
-    const { result: entries, cids } = await root.getEntries(['a', 'zz'])
+    const { result: entries, cids } = await root.getEntries(['^', 'zz'])
     same((await cids.all()).size, 5)
     same(entries.length, 2)
     const [a, zz] = entries
-    same(a.key, 'a')
+    same(a.key, '^')
     same(a.value, 1)
     same(zz.key, 'zz')
     same(zz.value, 2)
-    const { result: values } = await root.getMany(['a', 'zz'])
+    const { result: values } = await root.getMany(['^', 'zz'])
     same(values, [1, 2])
   })
   it('getRangeEntries', async () => {
@@ -110,9 +110,9 @@ describe('map', () => {
     verify(entries, 1, 8)
     entries = await range('', 'zzz')
     verify(entries)
-    entries = await range('a', 'zz')
+    entries = await range('^', 'zz')
     verify(entries, 0, 9)
-    entries = await range('a', 'c')
+    entries = await range('^', 'c')
     verify(entries, 0, 3)
   })
   it('getAllEntries', async () => {
@@ -154,7 +154,7 @@ describe('map', () => {
     same(await _get('dd'), 2)
     same(await _get('d'), -1)
     const expected = [
-      ['a', 1],
+      ['^', 1],
       ['b', 1],
       ['bb', 2],
       ['c', 1],

--- a/test/test-map.js
+++ b/test/test-map.js
@@ -369,7 +369,11 @@ describe('map', () => {
       // console.log('writing', key, value)
       const bulk = [{ key, value }]
       const { blocks, root } = await mapRoot.bulk(bulk)
-      await Promise.all(blocks.map((block) => put(block)))
+      // await Promise.all(blocks.map((block) => await put(block)))
+      for (const bl of blocks) {
+        await put(bl)
+      }
+
       mapRoot = root
       await mapRoot
         .get(key)

--- a/test/test-map.js
+++ b/test/test-map.js
@@ -44,7 +44,7 @@ const list = createList([
   ['ff', 2],
   ['h', 1],
   ['z', 1],
-  ['zz', 2],
+  ['zz', 2]
 ])
 
 describe('map', () => {
@@ -59,7 +59,7 @@ describe('map', () => {
       [true, undefined, 1, false],
       [undefined, true, 5, true],
       [undefined, true, 1, true],
-      [undefined, true, 2, false],
+      [undefined, true, 2, false]
     ].map(([isLeaf, isBranch, entries, closed]) => ({ isLeaf, isBranch, entries, closed }))
     let root
     for await (const node of create({ get, compare, list, ...opts })) {
@@ -146,7 +146,7 @@ describe('map', () => {
     verify(entries)
     const bulk = [
       { key: 'dd', value: 2 },
-      { key: 'd', value: -1 },
+      { key: 'd', value: -1 }
     ]
     const { blocks, root } = await last.bulk(bulk)
     await Promise.all(blocks.map((block) => put(block)))
@@ -162,7 +162,7 @@ describe('map', () => {
       ['ff', 2],
       ['h', 1],
       ['z', 1],
-      ['zz', 2],
+      ['zz', 2]
     ]
     for (const [key, value] of expected) {
       same(await _get(key), value)
@@ -360,7 +360,7 @@ describe('map', () => {
     })
     same(result, 1)
 
-    const randFun = mulberry32(1)
+    // const randFun = mulberry32(1)
     const errors = []
     const limit = 500
     for (let rowCount = 0; rowCount < limit; rowCount++) {
@@ -371,17 +371,22 @@ describe('map', () => {
       const { blocks, root } = await mapRoot.bulk(bulk)
       await Promise.all(blocks.map((block) => put(block)))
       mapRoot = root
-      await mapRoot.get(key).then(()=>{
-        // console.log('got', key, value)
-      }).catch((e) => {
-        errors.push({key, value, rowCount})
-      })
-
+      await mapRoot
+        .get(key)
+        .then(() => {
+          // console.log('got', key, value)
+        })
+        .catch((e) => {
+          errors.push({ key, value, rowCount })
+        })
     }
-    console.log('ok keys',limit - errors.length)
-    console.log('unhandled keys',errors.length)
+    console.log('ok keys', limit - errors.length)
+    console.log('unhandled keys', errors.length)
     // anything with charcode less than 97, eg before lowercase a, will fail
-    console.log('unhandled keys',errors.map(({key, rowCount})=>key))
+    console.log(
+      'unhandled keys',
+      errors.map(({ key, rowCount }) => key)
+    )
     same(errors.length, 0)
   })
   it.skip('big map', async () => {
@@ -455,7 +460,7 @@ describe('map', () => {
   }).timeout(60 * 1000)
 })
 
-function mulberry32(a) {
+function mulberry32 (a) {
   return function () {
     let t = (a += 0x6d2b79f5)
     t = Math.imul(t ^ (t >>> 15), t | 1)


### PR DESCRIPTION
This finds out that any key starting with a character less than `a` (char code 97) is not acceptable as the first character of a map key.

There are two skip tests here that are slow to run, one fails along with this, and the other passes. It's probably worth checking the fix with those and then leaving them skipped for CI