### PR TITLE
avoid saving the same block twice

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -151,7 +151,7 @@ async function generateBranchEntries (that, newLeaves, results, opts) {
 
 async function processRoot (that, results, bulk, nodeOptions) {
   const root = results.root
-  results.blocks.push({ block: await root.encode(), node: root })
+  // results.blocks.push({ block: await root.encode(), node: root })
 
   that.cache.set(root)
   const opts = nodeOptions.opts


### PR DESCRIPTION
The removed save looks redundant.